### PR TITLE
support mysql by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,30 +38,55 @@ if (production) {
   console.log("App URL: " + appUrl);
   // console.log(appEnv);
   // console.log(appEnv.getServices());
-  var sqlCredentials = appEnv.getServiceCreds(/pg/);
+  var mysqlCredentials = appEnv.getServiceCreds(/mysql/);
+  var pgCredentials = appEnv.getServiceCreds(/pg/);
   var mailCredentials = appEnv.getServiceCreds(/mail/);
   var s3Credentials = appEnv.getServiceCreds(/s3/);
 
-  console.log(sqlCredentials);
+  console.log(mysqlCredentials);
+  console.log(pgCredentials);
   console.log(mailCredentials);
   console.log(s3Credentials);
 
-  config['production'] = {
-    url: appUrl,
-    database: {
-      client: 'pg',
-      connection: sqlCredentials.uri,
-      pool: {
-        min: 2,
-        max: 4
+  if (mysqlCredentials !== null) {
+    config['production'] = {
+      url: appUrl,
+      database: {
+        client: 'mysql',
+        connection: mysqlCredentials.uri,
+        pool: {
+          min: 2,
+          max: 4
+        },
+        debug: false
       },
-      debug: false
-    },
-    server: {
-      host: appEnv.bind,
-      port: appEnv.port
-    },
-    logging: false
+      server: {
+        host: appEnv.bind,
+        port: appEnv.port
+      },
+      logging: false
+    }
+  } else if (pgCredentials !== null) {
+    config['production'] = {
+      url: appUrl,
+      database: {
+        client: 'pg',
+        connection: pgCredentials.uri,
+        pool: {
+          min: 2,
+          max: 4
+        },
+        debug: false
+      },
+      server: {
+        host: appEnv.bind,
+        port: appEnv.port
+      },
+      logging: false
+    }
+  } else {
+    console.log("ERROR: cannot find PG nor MySQL service instance")
+    exit(1);
   }
 
   if (s3Credentials !== null) {

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -4,6 +4,7 @@ applications:
   memory: 256M
   disk_quota: 1G
   buildpack: nodejs_buildpack
+  health-check-type: http
   routes:
   - route: www.starkandwayne.com/blog
   - route: starkandwayne.com/blog

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,9 +4,11 @@ applications:
   memory: 256M
   disk_quota: 1G
   buildpack: nodejs_buildpack
+  health-check-type: http
   routes:
   - route: blog-staging.starkandwayne.com
   services:
   - ghost-email
   - ghost-s3
   - ghost-pg
+  - ghost-mysql


### PR DESCRIPTION
Use Ghost Labs' export + import to migrate from PG to MySQL

@ramonskie @norman-abramovitz can you have a quick look at this; and confirm that https://blog-staging.starkandwayne.com/bucc-bbr-finally/ looks good. Its deployed in `cf t -o starkandwayne -s blog-staging` under the `ghost-mysql` service instance. 

Once we migrate production to mysql, the postgresql code paths in `config.js` can be removed. Ghost v1 does not support postgresql as discovered by @ramonskie last year.