### PR TITLE
Reading Time functionality in the blog

### DIFF
--- a/content/themes/ghostium-starkandwayne/post.hbs
+++ b/content/themes/ghostium-starkandwayne/post.hbs
@@ -16,7 +16,7 @@
     <img class="header" src="{{feature_image}}">
     {{/if}}
 
-    <h1 class="title"><span datetime="{{date published_at format="YYYY-MM-DD"}}" itemprop="datePublished">{{date published_at form="MMM DD, YYYY"}}</span>
+    <h1 class="title"><span datetime="{{date published_at format="YYYY-MM-DD"}}" itemprop="datePublished">{{date published_at form="MMM DD, YYYY"}}</span><span class="readingtime" style="padding-left: 3rem;">2 min read</span>>
       {{{title}}}</h1>
 
       <div class="page-content">


### PR DESCRIPTION
This commit includes a reading time functionality in our blog. There is a need of a CSS style change in the website in the near future that should change the "display:block" to
"display: inline" for making the published date and reading time on the same line.