### PR TITLE
Fix for reading_time bug

### DIFF
--- a/content/themes/ghostium-starkandwayne/post.hbs
+++ b/content/themes/ghostium-starkandwayne/post.hbs
@@ -16,7 +16,7 @@
     <img class="header" src="{{feature_image}}">
     {{/if}}
 
-    <h1 class="title"><span datetime="{{date published_at format="YYYY-MM-DD"}}" itemprop="datePublished">{{date published_at form="MMM DD, YYYY"}}</span><span class="readingtime" style="padding-left: 3rem;">2 min read</span>>
+    <h1 class="title"><span datetime="{{date published_at format="YYYY-MM-DD"}}" itemprop="datePublished">{{date published_at form="MMM DD, YYYY"}}</span><span class="readingtime" style="padding-left: 3rem;">{{reading_time}}</span>>
       {{{title}}}</h1>
 
       <div class="page-content">

--- a/content/themes/ghostium-starkandwayne/post.hbs
+++ b/content/themes/ghostium-starkandwayne/post.hbs
@@ -16,7 +16,7 @@
     <img class="header" src="{{feature_image}}">
     {{/if}}
 
-    <h1 class="title"><span datetime="{{date published_at format="YYYY-MM-DD"}}" itemprop="datePublished">{{date published_at form="MMM DD, YYYY"}}</span>
+    <h1 class="title"><span datetime="{{date published_at format="YYYY-MM-DD"}}" itemprop="datePublished">{{date published_at form="MMM DD, YYYY"}}</span><span class="readingtime" style="padding-left: 3rem;">2 min read</span>>
       {{{title}}}</h1>
 
       <div class="page-content">


### PR DESCRIPTION
I forgot to use the actual `reading_time` helper in the reading time span earlier and it got merged. Instead of that, I included the text "2 min read". I suspect I copied the output from the web inspector and messed it up. That's why every blog post showed a default 2 min read. Fixed it here.

@jhunt Also, can you please make that `display: block` to `inline` so that the reading time is on the same line as the published date? Thanks. 